### PR TITLE
fix(auth): add CSRF state parameter to OAuth authorization flow

### DIFF
--- a/auth/twitch_auth.py
+++ b/auth/twitch_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import secrets
 import time
 import urllib.parse
 import urllib.request
@@ -136,20 +137,25 @@ class TokenManager:
     # Login flow (local callback server)
     # ------------------------------------------------------------------
 
-    def authorization_url(self) -> str:
-        """Build the Twitch authorization URL."""
+    def authorization_url(self, state: str) -> str:
+        """Build the Twitch authorization URL including a CSRF state token."""
         params = urllib.parse.urlencode(
             {
                 "client_id": self.client_id,
                 "redirect_uri": self.redirect_uri,
                 "response_type": "code",
                 "scope": self.scopes,
+                "state": state,
             }
         )
         return f"{TWITCH_AUTH_URL}?{params}"
 
-    def _wait_for_code(self) -> str:
-        """Start a local HTTP server and block until the OAuth callback arrives."""
+    def _wait_for_code(self, expected_state: str) -> str:
+        """Start a local HTTP server and block until the OAuth callback arrives.
+
+        Validates the *state* parameter against *expected_state* to prevent
+        CSRF attacks (RFC 6749 §10.12).
+        """
         parsed = urllib.parse.urlparse(self.redirect_uri)
         port = parsed.port or 80
         captured: dict[str, str] = {}
@@ -159,6 +165,12 @@ class TokenManager:
                 parsed_path = urllib.parse.urlparse(self.path)
                 if parsed_path.path == "/callback":
                     params = urllib.parse.parse_qs(parsed_path.query)
+                    received_state = params.get("state", [""])[0]
+                    if not secrets.compare_digest(received_state, expected_state):
+                        self.send_response(403)
+                        self.end_headers()
+                        self.wfile.write(b"Invalid state parameter. Possible CSRF attack.")
+                        return
                     if "code" in params:
                         captured["code"] = params["code"][0]
                         self.send_response(200)
@@ -186,10 +198,11 @@ class TokenManager:
 
     def login(self) -> str:
         """Run the full OAuth login flow and return the new access token."""
-        url = self.authorization_url()
+        state = secrets.token_urlsafe(16)
+        url = self.authorization_url(state=state)
         print(f"\nOpen the following URL in your browser to authorize:\n\n  {url}\n")
         print(f"Waiting for OAuth callback on {self.redirect_uri} …")
-        code = self._wait_for_code()
+        code = self._wait_for_code(expected_state=state)
         tokens = self.exchange_code(code)
         self.save_tokens(tokens)
         print("Tokens saved successfully.")

--- a/auth/twitch_auth.py
+++ b/auth/twitch_auth.py
@@ -170,6 +170,7 @@ class TokenManager:
                         self.send_response(403)
                         self.end_headers()
                         self.wfile.write(b"Invalid state parameter. Possible CSRF attack.")
+                        captured["error"] = "csrf"
                         return
                     if "code" in params:
                         captured["code"] = params["code"][0]
@@ -191,9 +192,11 @@ class TokenManager:
 
         server = HTTPServer(("", port), _Handler)
         server.timeout = 300  # 5-minute window to complete login
-        while "code" not in captured:
+        while "code" not in captured and "error" not in captured:
             server.handle_request()
         server.server_close()
+        if "error" in captured:
+            raise RuntimeError("OAuth login aborted: CSRF state mismatch.")
         return captured["code"]
 
     def login(self) -> str:
@@ -227,7 +230,5 @@ class TokenManager:
                 return tokens["access_token"]
             except Exception as exc:
                 print(f"Token refresh failed ({exc}). Re-authenticating…")
-
-        return self.login()
 
         return self.login()

--- a/tests/test_twitch_auth.py
+++ b/tests/test_twitch_auth.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import time
+import urllib.parse
+from io import BytesIO
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -115,18 +117,23 @@ class TestTokenValidity:
 class TestAuthorizationUrl:
     def test_contains_client_id(self, tmp_path):
         manager = _make_manager(tmp_path)
-        url = manager.authorization_url()
+        url = manager.authorization_url(state="teststate")
         assert "client_id=cid" in url
 
     def test_contains_response_type_code(self, tmp_path):
         manager = _make_manager(tmp_path)
-        url = manager.authorization_url()
+        url = manager.authorization_url(state="teststate")
         assert "response_type=code" in url
 
     def test_contains_scopes(self, tmp_path):
         manager = _make_manager(tmp_path)
-        url = manager.authorization_url()
+        url = manager.authorization_url(state="teststate")
         assert "scope=" in url
+
+    def test_contains_state_parameter(self, tmp_path):
+        manager = _make_manager(tmp_path)
+        url = manager.authorization_url(state="mycsrftoken")
+        assert "state=mycsrftoken" in url
 
 
 # ---------------------------------------------------------------------------
@@ -248,3 +255,70 @@ class TestGetToken:
 
         mock_login.assert_called_once()
         assert token == "brand_new_tok"
+
+
+# ---------------------------------------------------------------------------
+# TestCsrfStateValidation
+# ---------------------------------------------------------------------------
+
+
+class TestCsrfStateValidation:
+    """Verify that _wait_for_code rejects callbacks with a mismatched state."""
+
+    def _make_mock_request(self, code: str, state: str) -> MagicMock:
+        """Build a minimal fake request object for _Handler.do_GET."""
+        query = urllib.parse.urlencode({"code": code, "state": state})
+        mock_request = MagicMock()
+        mock_request.makefile.return_value = BytesIO(
+            f"GET /callback?{query} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode()
+        )
+        return mock_request
+
+    def test_login_generates_unique_states(self, tmp_path):
+        """Each login call must use a distinct state value."""
+        manager = _make_manager(tmp_path)
+        states: list[str] = []
+
+        def capture_url(state: str) -> str:
+            states.append(state)
+            return f"https://example.com?state={state}"
+
+        with (
+            patch.object(manager, "authorization_url", side_effect=capture_url),
+            patch.object(manager, "_wait_for_code", return_value="code_x"),
+            patch.object(manager, "exchange_code", return_value={"access_token": "tok", "refresh_token": "", "expires_at": 9999, "scope": [], "token_type": "bearer"}),
+            patch.object(manager, "save_tokens"),
+            patch("builtins.print"),
+        ):
+            manager.login()
+            manager.login()
+
+        assert len(states) == 2
+        assert states[0] != states[1]
+
+    def test_wait_for_code_passes_expected_state_to_login(self, tmp_path):
+        """login() must forward the generated state to _wait_for_code."""
+        manager = _make_manager(tmp_path)
+        received: dict[str, str] = {}
+
+        def capture_wait(expected_state: str) -> str:
+            received["state"] = expected_state
+            return "auth_code"
+
+        captured_url: list[str] = []
+
+        def capture_url(state: str) -> str:
+            captured_url.append(state)
+            return f"https://example.com?state={state}"
+
+        with (
+            patch.object(manager, "authorization_url", side_effect=capture_url),
+            patch.object(manager, "_wait_for_code", side_effect=capture_wait),
+            patch.object(manager, "exchange_code", return_value={"access_token": "tok", "refresh_token": "", "expires_at": 9999, "scope": [], "token_type": "bearer"}),
+            patch.object(manager, "save_tokens"),
+            patch("builtins.print"),
+        ):
+            manager.login()
+
+        # The state passed to authorization_url and _wait_for_code must match
+        assert captured_url[0] == received["state"]

--- a/tests/test_twitch_auth.py
+++ b/tests/test_twitch_auth.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import socket
+import threading
 import time
+import urllib.error
 import urllib.parse
-from io import BytesIO
+import urllib.request
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -24,6 +27,34 @@ def _make_manager(tmp_path) -> TokenManager:
         client_secret="csecret",
         token_path=str(tmp_path / ".secrets" / "twitch_tokens.json"),
     )
+
+
+def _make_manager_on_port(tmp_path, port: int) -> TokenManager:
+    return TokenManager(
+        client_id="cid",
+        client_secret="csecret",
+        redirect_uri=f"http://localhost:{port}/callback",
+        token_path=str(tmp_path / ".secrets" / "twitch_tokens.json"),
+    )
+
+
+def _free_port() -> int:
+    """Return an available TCP port on localhost."""
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_server(port: int, timeout: float = 3.0) -> None:
+    """Block until the TCP port is accepting connections or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("localhost", port), timeout=0.05):
+                return
+        except OSError:
+            time.sleep(0.02)
+    raise TimeoutError(f"Server on port {port} did not start in time.")
 
 
 def _make_token_data(expires_delta: int = 3600) -> dict[str, Any]:
@@ -265,14 +296,17 @@ class TestGetToken:
 class TestCsrfStateValidation:
     """Verify that _wait_for_code rejects callbacks with a mismatched state."""
 
-    def _make_mock_request(self, code: str, state: str) -> MagicMock:
-        """Build a minimal fake request object for _Handler.do_GET."""
-        query = urllib.parse.urlencode({"code": code, "state": state})
-        mock_request = MagicMock()
-        mock_request.makefile.return_value = BytesIO(
-            f"GET /callback?{query} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode()
-        )
-        return mock_request
+    def _call_callback(self, port: int, **params: str) -> int:
+        """Fire a GET /callback request and return the HTTP status code."""
+        query = urllib.parse.urlencode(params)
+        url = f"http://localhost:{port}/callback?{query}"
+        try:
+            with urllib.request.urlopen(url) as resp:
+                return resp.status
+        except urllib.error.HTTPError as exc:
+            return exc.code
+        except urllib.error.URLError:
+            return 0  # server already closed
 
     def test_login_generates_unique_states(self, tmp_path):
         """Each login call must use a distinct state value."""
@@ -283,10 +317,17 @@ class TestCsrfStateValidation:
             states.append(state)
             return f"https://example.com?state={state}"
 
+        _fake_tokens = {
+            "access_token": "tok",
+            "refresh_token": "",
+            "expires_at": 9999,
+            "scope": [],
+            "token_type": "bearer",
+        }
         with (
             patch.object(manager, "authorization_url", side_effect=capture_url),
             patch.object(manager, "_wait_for_code", return_value="code_x"),
-            patch.object(manager, "exchange_code", return_value={"access_token": "tok", "refresh_token": "", "expires_at": 9999, "scope": [], "token_type": "bearer"}),
+            patch.object(manager, "exchange_code", return_value=_fake_tokens),
             patch.object(manager, "save_tokens"),
             patch("builtins.print"),
         ):
@@ -311,10 +352,17 @@ class TestCsrfStateValidation:
             captured_url.append(state)
             return f"https://example.com?state={state}"
 
+        _fake_tokens = {
+            "access_token": "tok",
+            "refresh_token": "",
+            "expires_at": 9999,
+            "scope": [],
+            "token_type": "bearer",
+        }
         with (
             patch.object(manager, "authorization_url", side_effect=capture_url),
             patch.object(manager, "_wait_for_code", side_effect=capture_wait),
-            patch.object(manager, "exchange_code", return_value={"access_token": "tok", "refresh_token": "", "expires_at": 9999, "scope": [], "token_type": "bearer"}),
+            patch.object(manager, "exchange_code", return_value=_fake_tokens),
             patch.object(manager, "save_tokens"),
             patch("builtins.print"),
         ):
@@ -322,3 +370,67 @@ class TestCsrfStateValidation:
 
         # The state passed to authorization_url and _wait_for_code must match
         assert captured_url[0] == received["state"]
+
+    def test_wrong_state_returns_403_and_aborts(self, tmp_path):
+        """_wait_for_code must reject a mismatched state with HTTP 403 and raise."""
+        port = _free_port()
+        manager = _make_manager_on_port(tmp_path, port)
+        result: dict[str, object] = {}
+
+        def run_server() -> None:
+            try:
+                result["code"] = manager._wait_for_code("correct-state")
+            except RuntimeError as exc:
+                result["error"] = str(exc)
+
+        t = threading.Thread(target=run_server, daemon=True)
+        t.start()
+        _wait_for_server(port)
+
+        status = self._call_callback(port, code="stolen", state="wrong-state")
+        assert status == 403
+
+        # Server aborts after CSRF mismatch — no unblock needed
+        t.join(timeout=5)
+        assert "code" not in result
+        assert "CSRF" in str(result.get("error", ""))
+
+    def test_correct_state_captures_code(self, tmp_path):
+        """_wait_for_code must accept a matching state and return the code."""
+        port = _free_port()
+        manager = _make_manager_on_port(tmp_path, port)
+        result: dict[str, object] = {}
+
+        def run_server() -> None:
+            result["code"] = manager._wait_for_code("valid-state")
+
+        t = threading.Thread(target=run_server, daemon=True)
+        t.start()
+        _wait_for_server(port)
+
+        self._call_callback(port, code="auth_code_ok", state="valid-state")
+        t.join(timeout=5)
+        assert result.get("code") == "auth_code_ok"
+
+    def test_missing_state_param_returns_403(self, tmp_path):
+        """A callback with no state parameter must be rejected as a CSRF attempt."""
+        port = _free_port()
+        manager = _make_manager_on_port(tmp_path, port)
+        result: dict[str, object] = {}
+
+        def run_server() -> None:
+            try:
+                result["code"] = manager._wait_for_code("expected")
+            except RuntimeError as exc:
+                result["error"] = str(exc)
+
+        t = threading.Thread(target=run_server, daemon=True)
+        t.start()
+        _wait_for_server(port)
+
+        # Request without state — compare_digest("", "expected") → False → 403
+        status = self._call_callback(port, code="evil_code")
+        assert status == 403
+
+        t.join(timeout=5)
+        assert "CSRF" in str(result.get("error", ""))


### PR DESCRIPTION
## Summary

Fixes #46 — CSRF vulnerability in the OAuth authorization flow.

## Changes

### `auth/twitch_auth.py`
- Added `import secrets`
- `authorization_url(state)` now accepts a `state` parameter and includes it in the Twitch authorization URL query string
- `_wait_for_code(expected_state)` now validates the `state` parameter from the callback using `secrets.compare_digest` (timing-safe comparison); returns HTTP 403 on mismatch
- `login()` generates a cryptographically random state via `secrets.token_urlsafe(16)`, passes it to both functions

### `tests/test_twitch_auth.py`
- Updated existing `TestAuthorizationUrl` tests to pass the required `state` argument
- Added `test_contains_state_parameter` to assert the state value appears in the URL
- Added `TestCsrfStateValidation` class with two tests:
  - `test_login_generates_unique_states`: each `login()` call uses a distinct state
  - `test_wait_for_code_passes_expected_state_to_login`: the same state is forwarded to `_wait_for_code`

## Security

- Prevents CSRF attacks per RFC 6749 §10.12 and OWASP A01
- Uses `secrets.compare_digest` to avoid timing-side-channel leaks